### PR TITLE
Fixed eclipsepass.org and eclipse-pass.org

### DIFF
--- a/certs.jsonnet
+++ b/certs.jsonnet
@@ -54,15 +54,12 @@
       "tracecompass.org",
     ],
 
-    "eclipse-pass.org": [
-      "eclipse-pass.org",
-      "www.eclipse-pass.org",
+    "demo.eclipse-pass.org": [
       "demo.eclipse-pass.org",
       "nightly.eclipse-pass.org",
     ],
 
-    "eclipsepass.org": [
-      "eclipsepass.org",
+    "demo.eclipsepass.org": [
       "demo.eclipsepass.org",
       "nightly.eclipsepass.org",
     ],

--- a/certs.jsonnet
+++ b/certs.jsonnet
@@ -54,12 +54,12 @@
       "tracecompass.org",
     ],
 
-    "demo.eclipse-pass.org": [
+    "eclipse-pass.org": [
       "demo.eclipse-pass.org",
       "nightly.eclipse-pass.org",
     ],
 
-    "demo.eclipsepass.org": [
+    "eclipsepass.org": [
       "demo.eclipsepass.org",
       "nightly.eclipsepass.org",
     ],


### PR DESCRIPTION
Removing bare domain (and www subdomain) as they are pointing to GitHub pages now.