### PR TITLE
Added jakartablogs.ee website

### DIFF
--- a/certs.jsonnet
+++ b/certs.jsonnet
@@ -49,6 +49,11 @@
       "websites.eclipseprojects.io",
     ],
 
+    "jakartablogs.ee": [
+      "jakartablogs.ee",
+      "www.jakartablogs.ee",
+    ],
+
     "planeteclipse.org": [
       "planeteclipse.org",
       "www.planeteclipse.org",


### PR DESCRIPTION
We want to use letsencrypt for jakartablogs.ee instead of renewing with Digicert