### PR TITLE
Remove eclipseconverge as it redirects to eclipsecon at our upstream,…

### DIFF
--- a/certs.jsonnet
+++ b/certs.jsonnet
@@ -37,8 +37,6 @@
     "eclipsecon.org": [
       "eclipsecon.org",
       "www.eclipsecon.org",
-      "eclipseconverge.org",
-      "www.eclipseconverge.org",
     ],
 
     "eclipseide.org": [


### PR DESCRIPTION
… thus breaking letsencrypt

Remove eclipse-pass and eclipsepass as they are served via Github